### PR TITLE
Improve QR code, add nice defaults for use with hub-monorepo

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,11 +1,14 @@
 # DB
-DATABASE_URL="postgresql://postgres:admin@localhost:5432/postgres?schema=public"
+DATABASE_URL="postgresql://app:password@localhost:6541/hub?schema=public"
 
-# Farcaster (optional: only required for writing)
-FC_HUB_URL=
+# Farcaster Hub (optional: only required for writing)
+# The format is <host>:<port>, do not include the protocol
+FC_HUB_URL=localhost:2283
 
 # Client name (used for signer and client identification)
 NEXT_PUBLIC_FC_CLIENT_NAME=Opencast
 
+# WalletConnectV2 Id (you can get your own @ https://walletconnect.com/)
+NEXT_PUBLIC_WALLETCONNECT_ID=
 # Dev URL
 NEXT_PUBLIC_URL=http://localhost:3000

--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,9 @@ DATABASE_URL="postgresql://app:password@localhost:6541/hub?schema=public"
 # The format is <host>:<port>, do not include the protocol
 FC_HUB_URL=localhost:2283
 
+# If using the hub monorepo this should be set to false unless you setup TLS
+FC_HUB_USE_TLS=false
+
 # Client name (used for signer and client identification)
 NEXT_PUBLIC_FC_CLIENT_NAME=Opencast
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "tsconfig.json"
+  },
+  "settings": {
+    "import/resolver": {
+      "typescript": true,
+      "node": true
+    }
+  }
+
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ next-env.d.ts
 *.py
 
 .env
+
+.idea

--- a/src/components/login/sign-in-with-warpcast.tsx
+++ b/src/components/login/sign-in-with-warpcast.tsx
@@ -112,7 +112,7 @@ const WarpcastAuthPopup = () => {
     <div>
       {deepLinkUrl && (
         <div>
-          <div>
+          <div className={'rounded bg-white p-2'}>
             <QRCode value={deepLinkUrl} />{' '}
           </div>
           <span className='pt-4 text-gray-500'>

--- a/src/lib/farcaster/index.ts
+++ b/src/lib/farcaster/index.ts
@@ -1,11 +1,18 @@
-import { getSSLHubRpcClient, HubRpcClient } from '@farcaster/hub-nodejs';
+import {
+  getInsecureHubRpcClient,
+  getSSLHubRpcClient,
+  HubRpcClient
+} from '@farcaster/hub-nodejs';
 
 const globalForFarcaster = global as unknown as {
   hubClient: HubRpcClient | undefined;
 };
 
 export const hubClient =
-  globalForFarcaster.hubClient ?? getSSLHubRpcClient(process.env.FC_HUB_URL!);
+  globalForFarcaster.hubClient ??
+  (process.env.FC_HUB_USE_TLS
+    ? getSSLHubRpcClient(process.env.FC_HUB_URL!)
+    : getInsecureHubRpcClient(process.env.FC_HUB_URL!));
 
 if (process.env.NODE_ENV !== 'production')
   globalForFarcaster.hubClient = hubClient;


### PR DESCRIPTION
The PR adds some IDE compatibility stuff, ignoring Intellij files and setting up a very basic Eslint config. It also updates the `.env.sample` with one missing key and adds the ability to configure an insecure hub client which is required with the default [hub-monorepo](https://github.com/farcasterxyz/hub-monorepo) docker-compose instance. 