### PR TITLE
Update .env.sample and README.md

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 ## Indexer DB
-DATABASE_URL="postgresql://app:password@localhost:6541/hub?schema=public"
+DATABASE_URL="postgresql://app:password@localhost:6541/replicator?schema=public"
 
 ## Farcaster Hub (optional: only required for writing)
 # The format is <host>:<port>, do not include the protocol

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It only depends on the reference Farcaster postgres indexer and optionally a hub
 
 ### Farcaster Replicator
 
-This project depends on the reference Farcaster PosgreSQL indexer. Follow the instructions at [replicate-data-postgres](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/hub-nodejs/examples/replicate-data-postgres) to set up an instance.
+This project depends on the reference Farcaster PosgreSQL indexer. Follow the instructions at [replicate-data-postgres](https://github.com/farcasterxyz/hub-monorepo/tree/main/apps/replicator) to set up an instance.
 
 ### Local
 


### PR DESCRIPTION
Update the DATABASE_URL in .env.sample

The DATABASE_URL in .env.sample was pointing to the wrong database. This commit updates it to point to the correct database.

Also, update the link in README.md

The link in README.md was pointing to the wrong location for setting up the Farcaster PosgreSQL indexer. This commit updates the link to point to the correct location.