### PR TITLE
Fixes font size of tweet progress bar.

### DIFF
--- a/src/components/input/progress-bar.tsx
+++ b/src/components/input/progress-bar.tsx
@@ -89,16 +89,12 @@ export function ProgressBar({
       <span
         className={cn(
           `absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[45%]
-           scale-50 opacity-0`,
+           scale-50 text-3xl opacity-0`,
           {
             'scale-100 opacity-100 transition': isCloseToLimit,
             'text-accent-red': isHittingCharLimit
           }
-        )},
-        style={{
-          fontSize: 'xx-large,
-          lineHeight: '1rem',
-        }}
+        )}
       >
         {remainingCharacters}
       </span>

--- a/src/components/input/progress-bar.tsx
+++ b/src/components/input/progress-bar.tsx
@@ -89,12 +89,16 @@ export function ProgressBar({
       <span
         className={cn(
           `absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[45%]
-           scale-50 text-xs opacity-0`,
+           scale-50 opacity-0`,
           {
             'scale-100 opacity-100 transition': isCloseToLimit,
             'text-accent-red': isHittingCharLimit
           }
-        )}
+        )},
+        style={{
+          fontSize: 'xx-large,
+          lineHeight: '1rem',
+        }}
       >
         {remainingCharacters}
       </span>

--- a/src/components/input/progress-bar.tsx
+++ b/src/components/input/progress-bar.tsx
@@ -88,8 +88,8 @@ export function ProgressBar({
       </i>
       <span
         className={cn(
-          `absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[45%]
-           scale-50 text-3xl opacity-0`,
+          `absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2
+           scale-50 text-3xl opacity-0 text-light-secondary dark:text-dark-secondary`,
           {
             'scale-100 opacity-100 transition': isCloseToLimit,
             'text-accent-red': isHittingCharLimit


### PR DESCRIPTION
Before: 
![image](https://github.com/stephancill/opencast/assets/886059/b5db8a06-656c-4ba1-a3fa-353f87a7c7af)

After: 
![image](https://github.com/stephancill/opencast/assets/886059/8bd06628-ba8b-43ca-bb1e-503132c34a70)

I couldn't figure out where the `text-xs` CSS class was coming from, otherwise I would have just created a `text-xxl` class.  Happy to move from inline style to CSS if someone can point me in the right direction!